### PR TITLE
Incorrect Google Form URL validation

### DIFF
--- a/components/Form/index.js
+++ b/components/Form/index.js
@@ -7,7 +7,7 @@ function handleSubmit(event, cb, error) {
   const formsLink = event.target[0].value;
   const gaSnippet = event.target[1].value;
   const email = event.target[2].value;
-  const formId = formsLink && formsLink.match(/\/forms\/d\/e\/(.*?)\//);
+  const formId = formsLink && formsLink.match(/\/forms\/d\/(.*?)\//);
   const gaId = gaSnippet && gaSnippet.match(/id=(.*?)"/);
   if (!formId || !gaId) {
     error('Your Google Form Link or Analytics Snippet is invalid.');


### PR DESCRIPTION
Match was failing for valid Google Form URLs because they don't always contain the subpath `/d/e` - namely, the `/e` is often missing.